### PR TITLE
Wrap "default" property in quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function(url){
   }
 
   return {
-    default: {
+    'default': {
       url: 'http://img.youtube.com/vi/' + id + '/default.jpg',
       width: 120,
       height: 90


### PR DESCRIPTION
`default` is a JS keyword, so without the change this module breaks in IE<9
